### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/AimpHTTP.cpp
+++ b/AimpHTTP.cpp
@@ -216,7 +216,7 @@ void AimpHTTP::RawRequestThread(void *args) {
     char buffer[10240];
     ZeroMemory(buffer, sizeof(buffer));
     int dataLen;
-    if ((dataLen = recv(webSocket, buffer, sizeof(buffer), 0) > 0)) {
+    if ((dataLen = recv(webSocket, buffer, sizeof(buffer), 0)) > 0) {
         if (char *body = strstr(buffer, "\r\n\r\n")) {
             body += 4;
             if (callback && m_initialized && Plugin::instance()->core())

--- a/Tools.h
+++ b/Tools.h
@@ -8,7 +8,7 @@
 #include "rapidjson/document.h"
 
 #define DebugA(...) { char msg[2048]; sprintf_s(msg, __VA_ARGS__); OutputDebugStringA(msg); }
-#define DebugW(...) { wchar_t msg[2048]; StringCchPrintfW(msg, sizeof(msg), __VA_ARGS__); OutputDebugStringW(msg); }
+#define DebugW(...) { wchar_t msg[2048]; StringCchPrintfW(msg, sizeof(msg)/sizeof(wchar_t), __VA_ARGS__); OutputDebugStringW(msg); }
 
 struct Tools {
     static std::wstring ToWString(const std::string &);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The number of processed elements should be passed to the 'StringCchPrintfW' function as the second argument instead of buffer's size in bytes. tools.cpp 43
[V593](https://www.viva64.com/en/w/v593/) Consider reviewing the expression of the 'A = B > C' kind. The expression is calculated as following: 'A = (B > C)'. aimphttp.cpp 219